### PR TITLE
add local uploaded files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,4 @@
 
 /config/secrets.yml
 
-/public/uploads/*
+/public/up


### PR DESCRIPTION
## What
　gitignoreにローカルでアップされる画像を追加しました。
## Why
　ローカルに保存される画像は本番環境には不要なため。