### PR TITLE
Revert "updated git ignore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,4 @@
 
 /config/secrets.yml
 
-/public/upload/*
+/public/up


### PR DESCRIPTION
Reverts Shogo-Sakai/freemarket_sample_58a#11

誤ってマスターにコミットしてしまったため。