### PR TITLE
Revert "add uploaded image to gitignore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,3 @@
 /config/master.key
 
 /config/secrets.yml
-
-/public/uploads/*


### PR DESCRIPTION
Reverts Shogo-Sakai/freemarket_sample_58a#9

誤ってマスターにコミットしてしまったため。