### PR TITLE
updated breadcrumb link to correct link.

### DIFF
--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,7 +1,7 @@
 = render "layouts/main-header"
 -content_for :current_page do
   %span.current_page
-    = link_to users_show_path do
+    = link_to users_path do
       マイページ
     %i.fa.fa-chevron-right
     %span.current_page__now


### PR DESCRIPTION
## What 
　パンくずリスト内のリンク先が変更されていなかったので正しく変更しました。
## Why
　ページがルート先不明のエラーで表示されなくなったため。

## Detail
　@TuBuKe @chiha-24 
　ルーティングが変更されたら、そのページへのリンクが貼ってあるページがちゃんと表示されるか確認するようにしましょう。
　※特に作業は必要ありません。今後気を付けましょう、という話です。
　　今回はルートを変更した際に変更箇所までチェックしきれていなかった為自戒の意味も込めて。。。