### PR TITLE
Create user my page

### DIFF
--- a/app/views/layouts/_user-navi.html.haml
+++ b/app/views/layouts/_user-navi.html.haml
@@ -2,7 +2,7 @@
   .user-mypage-wrapper__navi__menu
     %ul
       %li
-        = link_to users_path ,class:"link" do
+        = link_to "/users/#{current_user.id}" ,class:"link" do
           マイページ
           %i.fas.fa-chevron-right.menu-icon
       %li
@@ -18,7 +18,7 @@
           いいね！一覧
           %i.fas.fa-chevron-right.menu-icon
       %li
-        = link_to purchase_confirmation_products_path, class:"link" do
+        = link_to new_product_path, class:"link" do
           出品する
           %i.fas.fa-chevron-right.menu-icon
       %li

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -42,7 +42,7 @@
             = label :postal_code, '都道府県', class: 'signup-label'
             %span.signup-form-container__span.span-optional 任意
           .select-wrap.select-wrap__full
-            = select :user,:prefecture,['--'],{},{class: 'default-select default-select__full'}
+            = select :user,:prefecture,Prefecture.pluck(:name).unshift('--'),{},{class: 'default-select default-select__full'}
             %i.select-arrow.fas.fa-chevron-down
         .signup-form-container.mypage-form-container
           .signup-form-container__title

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -23,15 +23,15 @@
         .signup-form-container.registration-form__first-container.mypage-form-container
           .signup-form-container__title
             = label :name, 'お名前', class: 'signup-label'
-          手区 江来酢羽斗
+          = current_user.profile.post_family_name + current_user.profile.post_personal_name
         .signup-form-container.mypage-form-container
           .signup-form-container__title
             = label :name, 'お名前カナ', class: 'signup-label'
-          テックエキスパート
+          = current_user.profile.post_family_name_kana + current_user.profile.post_personal_name_kana
         .signup-form-container.mypage-form-container
           .signup-form-container__title
             = label :name, '生年月日', class: 'signup-label'
-          1098/09/28
+          = current_user.profile.birthyear.to_s + "/" + current_user.profile.birthmonth.to_s + "/" + current_user.profile.birthday.to_s
         .signup-form-container.mypage-form-container
           .signup-form-container__title
             = label :postal_code, '郵便番号', class: 'signup-label'

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,2 +1,0 @@
-%h1 Users#index
-%p Find me in app/views/users/index.html.haml


### PR DESCRIPTION
## What
　・ユーザーマイページのリンク先を正しく飛ぶように修正しました。
　・本人確認ページ（ユーザー編集ページ）の表示する内容をログインユーザーの情報にしました。
## Why
　・ダミーデータではなくログインユーザーの情報を載せてログイン時の情報を確認しやすくするため。