### PR TITLE
updated product show page's breadcrumb

### DIFF
--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -222,7 +222,7 @@
           %i.fas.fa-chevron-right
       %li.container__bread-crumbs__list__current-product
         %span
-          現在の商品名
+          = @product.title
           
 %footer
   =render "layouts/footer-advertisement"


### PR DESCRIPTION
## What
　商品詳細ページのパンくずリストを表示している商品名になるように修正しました。
## Why
　これまではどの商品詳細もダミーデータの「現在の商品」という表示になっていたため。