### PR TITLE
商品詳細ページの画像表示変更

### DIFF
--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -107,8 +107,10 @@
           }
           &__down{
             display: flex;
+            flex-wrap: wrap;
             &__thumbnail-image{
               opacity: .4;
+              height: 60px;
               &.thumbnail-current{
                 opacity: 1;
               }


### PR DESCRIPTION
# What
1.商品詳細ページにおいて、商品の画像が6枚以上の時に2段（5枚 × 2行）になるように変更。（以前（10枚 × 1行）は6枚目以降が見えなかった）
2.各画像の下部に6pxの幅ができていたため画像丁度のサイズになるように変更。

# Why
本物のメルカリに近づけるため。
投稿された写真は全て見えないと意味がないため。